### PR TITLE
fix: aggregate emissions which was break-down per ecosystem buble and docstrings

### DIFF
--- a/influence_toolkit/aura.py
+++ b/influence_toolkit/aura.py
@@ -14,6 +14,9 @@ from influence_toolkit.constants import VLAURA
 
 
 def aura_mint_ratio():
+    """
+    Fetches the current minting aura ratio per bal emitted
+    """
     aura = Contract(AURA)
     total_cliffs = aura.totalCliffs()
     cliff_reduction = aura.reductionPerCliff() / 1e18
@@ -26,12 +29,20 @@ def aura_mint_ratio():
 
 
 def weekly_emissions_after_fee(aura_mint_ratio, bal_price, aura_price):
+    """
+    Calculates the weekly ecosystem usd emissions and returns balancer emissions
+    with the fee reduction and the total emitted aura based on the current minting ratio
+    """
+    # NOTE: fee is uniquely taken out from the base protocol asset
     weekly_emissions_bal_after_fee = BALANCER_EMISSIONS * bal_price * (1 - AURA_FEE)
-    weekly_emissions_aura_after_fee = BALANCER_EMISSIONS * aura_mint_ratio * aura_price * (1 - AURA_FEE)
+    weekly_emissions_aura_after_fee = BALANCER_EMISSIONS * aura_mint_ratio * aura_price
     return weekly_emissions_bal_after_fee, weekly_emissions_aura_after_fee
 
 
 def aura_vebal_controlled():
+    """
+    Fetches the amount of veBAL controlled by Aura
+    """
     # contracts
     vebal = Contract(VEBAL)
 
@@ -44,6 +55,9 @@ def aura_vebal_controlled():
 
 
 def vebal_controlled_per_aura():
+    """
+    Calculates one much veBal is controlled per AURA
+    """
     # contracts
     vebal = Contract(VEBAL)
     vlAURA = Contract(VLAURA)
@@ -59,6 +73,10 @@ def vebal_controlled_per_aura():
 
 
 def get_rel_weights():
+    """
+    Retrieves the relative current weight for three of the DAO's gauges:
+    badger/wbtc, badger/reth and digg/wbtc/gravi
+    """
     # contracts
     gauge_controller = Contract(BALANCER_GAUGE_CONTROLLER)
 
@@ -86,6 +104,10 @@ def get_rel_weight_reducted(total_vebal_vp):
 
 
 def get_gravi_in_balancer_pool(balancer_vault):
+    """
+    Fetches the current amount of graviAURA deposited in
+    the digg/wbtc/gravi pool
+    """
     digg_pool_info = balancer_vault.getPoolTokens(POOL_ID_DIGG)
     gravi_in_digg_pool = digg_pool_info[1][2] / 1e18
     return gravi_in_digg_pool

--- a/influence_toolkit/bribe_hh.py
+++ b/influence_toolkit/bribe_hh.py
@@ -4,6 +4,9 @@ from influence_toolkit.constants import LLAMA_DASHBOARD_URL
 
 
 def get_usd_vlaura_hh():
+    """
+    Fetches last round $/vlAURA value
+    """
     r = requests.post(
         LLAMA_DASHBOARD_URL,
         json={"id": "bribes-overview-aura"},

--- a/influence_toolkit/coingecko.py
+++ b/influence_toolkit/coingecko.py
@@ -2,6 +2,9 @@ from pycoingecko import CoinGeckoAPI
 
 
 def get_aura_prices():
+    """
+    Fetches balancer and aura prices in usd
+    """
     prices = CoinGeckoAPI().get_price(["aura-finance", "balancer"], "usd")
     bal_price = prices["balancer"]["usd"]
     aura_price = prices["aura-finance"]["usd"]
@@ -10,6 +13,9 @@ def get_aura_prices():
 
 
 def get_bunni_prices():
+    """
+    Fetches lit price in usd
+    """
     prices = CoinGeckoAPI().get_price(["timeless"], "usd")
     lit_price = prices["timeless"]["usd"]
 
@@ -17,6 +23,9 @@ def get_bunni_prices():
 
 
 def get_badger_price():
+    """
+    Fetches badger price in usd
+    """
     prices = CoinGeckoAPI().get_price(["badger-dao"], "usd")
     badger_price = prices["badger-dao"]["usd"]
 
@@ -24,6 +33,9 @@ def get_badger_price():
 
 
 def get_convex_prices():
+    """
+    Fetches convex, curve and frax share price in usd
+    """
     prices = CoinGeckoAPI().get_price(["convex-finance", "curve-dao-token", "frax-share"], "usd")
     cvx_price = prices["convex-finance"]["usd"]
     crv_price = prices["curve-dao-token"]["usd"]

--- a/influence_toolkit/convex.py
+++ b/influence_toolkit/convex.py
@@ -15,6 +15,9 @@ from influence_toolkit.constants import BADGER_FRAXBP_CURVE_GAUGE
 
 
 def cvx_mint_ratio():
+    """
+    Fetches the current minting cvx ratio per crv emitted
+    """
     # https://docs.convexfinance.com/convexfinanceintegration/cvx-minting#mint-formula
     cvx = Contract(CONVEX)
     total_cliffs = cvx.totalCliffs()
@@ -27,6 +30,10 @@ def cvx_mint_ratio():
 
 
 def convex_biweekly_emissions(cvx_mint_ratio, cvx_price, crv_price, with_fee=True):
+    """
+    Calculates the weekly ecosystem usd emissions and returns curve emissions with the
+    fee reduction (conditionally) and the total emitted cvx based on the current minting ratio
+    """
     # borrow from: https://github.com/Badger-Finance/badger-ape/blob/convex_curve_wars/scripts/convex_curve_wars_votium.py#L29
     schedules = pd.read_csv(
         'https://raw.githubusercontent.com/Badger-Finance/badger-influence-analytics/master/notebooks/cvx_bribes/curve-release-schedule.csv'
@@ -48,12 +55,20 @@ def convex_biweekly_emissions(cvx_mint_ratio, cvx_price, crv_price, with_fee=Tru
 
 
 def frax_weekly_emissions(fxs_price):
+    """
+    Calculates the weekly fxs emissions in usd denomination
+    reducing the convex fee out of the FXS portion
+    """
     emissions_usd = FXS_DAILY_EMISSIONS * fxs_price * WEEK
+    # https://docs.convexfinance.com/convexfinance/faq/fees#convex-for-frax
     weekly_emissions_after_fee = emissions_usd * (1 - CVX_FEE)
     return weekly_emissions_after_fee
 
 
 def get_frax_gauge_weight():
+    """
+    Returns the badger/fraxbp gauge relative current weight in Frax ecosystem
+    """
     # contracts
     controller = Contract(FRAX_GAUGE_CONTROLLER)
 
@@ -63,6 +78,9 @@ def get_frax_gauge_weight():
 
 
 def get_badger_fraxbp_curve_gauge_weight():
+    """
+    Returns the badger/fraxbp gauge relative current weight in Curve ecosystem
+    """
     # contracts
     controller = Contract(CURVE_GAUGE_CONTROLLER)
 

--- a/influence_toolkit/df_helper.py
+++ b/influence_toolkit/df_helper.py
@@ -82,7 +82,9 @@ def display_current_epoch_df():
 
     # ecosystem emissions
     mint_ratio = aura_mint_ratio()
-    weekly_emissions_bal_usd, weekly_emissions_aura_usd = weekly_emissions_after_fee(mint_ratio, bal_price, aura_price)
+    weekly_emissions_bal_usd, weekly_emissions_aura_usd = weekly_emissions_after_fee(
+        mint_ratio, bal_price, aura_price
+    )
     biweekly_bal_emissions_usd = weekly_emissions_bal_usd * 2
     biweekly_aura_emissions_usd = weekly_emissions_aura_usd * 2
 
@@ -103,14 +105,14 @@ def display_current_epoch_df():
         biweekly_bal_emissions_usd,
         biweekly_bal_emissions_usd,
         biweekly_curve_emissions_usd,
-        np.nan
+        np.nan,
     ]
     lvl2_emissions = [
         biweekly_aura_emissions_usd,
         biweekly_aura_emissions_usd,
         biweekly_aura_emissions_usd,
         biweekly_convex_emissions_usd,
-        biweekly_bunni_emissions
+        biweekly_bunni_emissions,
     ]
     lvl3_emissions = [np.nan, np.nan, np.nan, biweekly_frax_emissions_usd, np.nan]
 
@@ -134,11 +136,15 @@ def display_current_epoch_df():
             usd_rev = capture * rel_weight * biweekly_bunni_emissions
         elif idx == Gauges.BADGER_FRAXBP:
             # here we include both set of emissions: crv, cvx & fxs
-            usd_rev_convex = capture * curve_weight * biweekly_convex_emissions_usd
+            total_convex_emissions_usd = (
+                biweekly_curve_emissions_usd + biweekly_convex_emissions_usd
+            )
+            usd_rev_convex = capture * curve_weight * total_convex_emissions_usd
             usd_rev_frax = capture * fxs_weight * biweekly_frax_emissions_usd
             usd_rev = usd_rev_convex + usd_rev_frax
         else:
-            usd_rev = capture * rel_weight * biweekly_aura_emissions_usd
+            total_aura_emissions_usd = biweekly_bal_emissions_usd + biweekly_aura_emissions_usd
+            usd_rev = capture * rel_weight * total_aura_emissions_usd
         gross_rev.append(usd_rev)
 
     # net revenue estimations
@@ -184,9 +190,9 @@ def display_current_epoch_df():
     df["Net Revenue"] = df["Net Revenue"].apply(dollar_format)
     df["Cost"] = df["Cost"].apply(dollar_format)
 
-    return df.set_index([
-        "Platform(s)", "Lvl1 Emissions", "Lvl2 Emissions", "Lvl3 Emissions", "Pool"
-    ])
+    return df.set_index(
+        ["Platform(s)", "Lvl1 Emissions", "Lvl2 Emissions", "Lvl3 Emissions", "Pool"]
+    )
 
 
 def display_aura_df():

--- a/influence_toolkit/incentives_cost.py
+++ b/influence_toolkit/incentives_cost.py
@@ -43,16 +43,19 @@ def get_incentives_cost(badger_price):
     Calculates the incentive cost in usd from the past round
     for different markets in HH: balancer & bunni
     """
-    # we cap reading for 2w back
+    # we cap reading for 2w-3w back, depending on market
     current_block = chain.blocks.height
     blocks_per_week = 60 * 60 * 24 * WEEK / SECONDS_PER_BLOCK
-    start_block = current_block - (blocks_per_week * 2)
+    start_block_balancer = current_block - (blocks_per_week * 2)
+    # NOTE: there may be the ocassion of having the bunni incentive
+    # 3w back whenever we run this method
+    start_block_bunni = current_block - (blocks_per_week * 3)
 
     # grab cost from all HH marketplaces in the past 2w
-    df_balancer_hh = _get_incentives_per_market(BALANCER_BRIBER_HH, start_block)
+    df_balancer_hh = _get_incentives_per_market(BALANCER_BRIBER_HH, start_block_balancer)
     # df_aura_hh = _get_incentives_per_market(AURA_BRIBER_HH, start_block)
     # df_frax_hh = _get_incentives_per_market(FRAX_BRIBER_HH, start_block)
-    df_bunni_hh = _get_incentives_per_market(BUNNI_BRIBER_HH, start_block)
+    df_bunni_hh = _get_incentives_per_market(BUNNI_BRIBER_HH, start_block_bunni)
 
     # filter incentives per gauge
     wbtc_badger_balancer_incentives = df_balancer_hh[

--- a/influence_toolkit/incentives_cost.py
+++ b/influence_toolkit/incentives_cost.py
@@ -18,6 +18,10 @@ from influence_toolkit.constants import WEEK
 
 
 def _get_incentives_per_market(briber_contract, start_block):
+    """
+    Retrieves `DepositBribe` events from briber contracts from
+    the starting block until most recent block
+    """
     df = Contract(briber_contract).DepositBribe.query(
         "transaction_hash",
         "block_number",
@@ -35,6 +39,10 @@ def _get_incentives_per_market(briber_contract, start_block):
 
 
 def get_incentives_cost(badger_price):
+    """
+    Calculates the incentive cost in usd from the past round
+    for different markets in HH: balancer & bunni
+    """
     # we cap reading for 2w back
     current_block = chain.blocks.height
     blocks_per_week = 60 * 60 * 24 * WEEK / SECONDS_PER_BLOCK


### PR DESCRIPTION
Now that the emissions per protocol where break down, it create a minor misc-calc in the revs section, which require to aggregate them before the multiplications.

Also got the chance to add a bit more of docstrings

<img width="1404" alt="Screenshot 2023-05-18 at 18 19 43" src="https://github.com/Badger-Finance/influence-toolkit/assets/84875062/43c8d3e5-a5f1-42a3-b282-a932e78c1f19">
